### PR TITLE
compilation fixes

### DIFF
--- a/src/pam_8021x.c
+++ b/src/pam_8021x.c
@@ -23,9 +23,11 @@
 #define PAM_SM_AUTH
 
 #include <security/pam_modules.h>
+#include <security/pam_ext.h>
 
 #include <syslog.h>
 #include <config.h>
+#include <string.h>
 
 #include <glib.h>
 #include <dbus/dbus.h>
@@ -230,7 +232,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags, int argc, const char **argv)
 
   if (authtok == NULL)
   {
-    if (pam_prompt (pamh, PAM_PROMPT_ECHO_OFF, &authtok, "Password:") != PAM_SUCCESS)
+    if (pam_prompt (pamh, PAM_PROMPT_ECHO_OFF, (char **)&authtok, "Password:") != PAM_SUCCESS)
     {
       pam_syslog (pamh, LOG_ERR, "Couldn't obtain password from pam_prompt.");
       return PAM_AUTHINFO_UNAVAIL;

--- a/src/pam_8021x.c
+++ b/src/pam_8021x.c
@@ -160,7 +160,7 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags, int argc, const char **argv)
 
   GError *error;
 
-  gboolean login_ok = TRUE;
+  //gboolean login_ok = TRUE;
 
   for (; argc-- > 0; ++argv)
   {

--- a/src/pam_8021x.c
+++ b/src/pam_8021x.c
@@ -175,13 +175,6 @@ pam_sm_authenticate (pam_handle_t *pamh, int flags, int argc, const char **argv)
     }
   }
 
-  /* Initialize GType system */
-  if (debug)
-  {
-    pam_syslog (pamh, LOG_INFO, "Initializing GType system.");
-  }
-  g_type_init();
-
   /* Get system bus */
   if (debug)
   {


### PR DESCRIPTION
Make it compile without errors or warnings (due to more needed headers and trivial type mismatches; compiled on ALT -- <https://packages.altlinux.org/en/Sisyphus/srpms/pam_8021x>).

Also remove the use of a deprecated function from glib2 (since 2.36), which also caused a warning.